### PR TITLE
Bug when loading with lispworks

### DIFF
--- a/temporary-file.lisp
+++ b/temporary-file.lisp
@@ -73,8 +73,8 @@
 
   (handler-case
       (logical-pathname-translations "TEMPORARY-FILES")
-    (#-clisp type-error
-     #+clisp simple-error ()
+    (#-(or clisp lispworks) type-error
+     #+(or clisp lispworks) simple-error ()
       (alexandria:if-let (default-temporary-directory (get-default-temporary-directory))
         (setf (logical-pathname-translations "TEMPORARY-FILES") `(("*.*.*" ,default-temporary-directory)))
         (warn "could not automatically determine a default mapping for TEMPORARY-FILES")))))


### PR DESCRIPTION
LispWorks 6.0 on linux requires the same fix that Clisp has for catching the load-temporary-files error.

I have not tried with other versions of lispworks.
